### PR TITLE
Fixed generation error

### DIFF
--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -29,8 +29,8 @@ import FlagSelect from "../../components/FlagSelect.astro";
       Das Ergebnis enthält eine Zeile am Ende, die mir Credits gibt. Das Entfernen ist optional, aber sehr geschätzt! Danke!
     </p>
     {
-      config_json.categories.map((category) => (
-        <OptionForm category={category} />
+      config_json.categories.map((category, index) => (
+        <OptionForm category={category} index={index}/>
       ))
     }
     <div class="flex justify-center">

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -31,8 +31,8 @@ import FlagSelect from "../../components/FlagSelect.astro";
       Dejarla ahí es opcional, ¡pero altamente apreciado! ¡Gracias!
     </p>
     {
-      config_json.categories.map((category) => (
-        <OptionForm category={category} />
+      config_json.categories.map((category, index) => (
+        <OptionForm category={category} index={index}/>
       ))
     }
     <div class="flex justify-center">

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -30,8 +30,8 @@ import FlagSelect from "../../components/FlagSelect.astro";
       mais apprecié. Merci beaucoup!
     </p>
     {
-      config_json.categories.map((category) => (
-        <OptionForm category={category} />
+      config_json.categories.map((category, index) => (
+        <OptionForm category={category} index={index}/>
       ))
     }
     <div class="flex justify-center">

--- a/src/pages/it/index.astro
+++ b/src/pages/it/index.astro
@@ -31,8 +31,8 @@ import FlagSelect from "../../components/FlagSelect.astro";
       Lasciarla è opzionale, ma molto apprezzato! Grazie!
     </p>
     {
-      config_json.categories.map((category) => (
-        <OptionForm category={category} />
+      config_json.categories.map((category, index) => (
+        <OptionForm category={category} index={index}/>
       ))
     }
     <div class="flex justify-center">


### PR DESCRIPTION
Added a index to fix the error with the "hide" button.

Ref: #29

--- Summary (just to explain a little more) ---

This pull request updates the `OptionForm` component usage across multiple language-specific pages to include an `index` parameter when iterating over `config_json.categories`. This change ensures that the index of each category is explicitly passed to the `OptionForm` component.

Updates to `OptionForm` component usage:

* [`src/pages/de/index.astro`](diffhunk://#diff-f2ea5366f640b29f549c67a3c0e24903b459a93f432162d07f60d6713b56bbb1L32-R33): Modified the `map` function to pass the `index` parameter to `OptionForm` alongside the `category`.
* [`src/pages/es/index.astro`](diffhunk://#diff-268e71c86775b7caa3963ea57add654c5e481fd8f1167c21a414ef2349657e63L34-R35): Updated the `map` function to include the `index` parameter for the `OptionForm` component.
* [`src/pages/fr/index.astro`](diffhunk://#diff-4665762b7da604f2cb8221647126d834f4eb711e0e680b1abec4254bc356b4e8L33-R34): Adjusted the `map` function to pass both `category` and `index` to `OptionForm`.
* [`src/pages/it/index.astro`](diffhunk://#diff-dcb563200b82cab925edbe626d4e92784f4c0972fb7e7e417d9718e9878dbb23L34-R35): Added the `index` parameter to the `OptionForm` component in the `map` function.